### PR TITLE
Update react peerDependencies to include v17

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "dist/**/*"
   ],
   "peerDependencies": {
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0"
+    "react": "^16.9.0 || ^17.0",
+    "react-dom": "^16.9.0 || ^17.0"
   },
   "dependencies": {
     "mousetrap": "^1.6.5",


### PR DESCRIPTION
NPM v7 and above throws an error when peer dependencies don't match.

This PR adds react v17 as a peer dependency.