### PR TITLE
Port changes: retain scroll position for operations on text area

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,8 @@
 # Textarea Markdown
 
-[![CI status][github-action-image]][github-action-url] [![codecov][codecov-image]][codecov-url] [![NPM version][npm-image]][npm-url]
+This is a fork of https://github.com/Resetand/textarea-markdown-editor
 
-[npm-image]: http://img.shields.io/npm/v/textarea-markdown-editor.svg
-[npm-url]: http://npmjs.org/package/textarea-markdown-editor
-[github-action-image]: https://github.com/Resetand/textarea-markdown-editor/actions/workflows/ci.yaml/badge.svg
-[github-action-url]: https://github.com/Resetand/textarea-markdown-editor/actions/workflows/ci.yaml
-[codecov-image]: https://codecov.io/gh/Resetand/textarea-markdown-editor/branch/master/graph/badge.svg?token=OBD8KR7Y98
-[codecov-url]: https://codecov.io/gh/Resetand/textarea-markdown-editor
-
-```bash
-npm install textarea-markdown-editor
-```
-
-> There are some breaking changes since v1.0.0 released, checkout the [release note](https://github.com/Resetand/textarea-markdown-editor/releases/tag/v1.0.0)
+The aim is to trim fix some of the quirks with the scroll position
 
 ---
 
@@ -265,3 +254,7 @@ export type CommandHandlerContext = {
 trigger: (command: string) => void;
 cursor: Cursor
 ```
+
+## Acknowledgements
+
+All praise goes to https://github.com/Resetand !

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a fork of https://github.com/Resetand/textarea-markdown-editor
 
-The aim is to trim fix some of the quirks with the scroll position
+The aim is to trim fix some of the quirks with the scroll position, there will be breaking changes, no compatibility planned.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "textarea-markdown-editor",
-  "version": "1.0.5-rc.3",
+  "name": "headless-mde",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "textarea-markdown-editor",
-      "version": "1.0.5-rc.3",
+      "name": "headless-mde",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "mousetrap": "^1.6.5"
@@ -18,7 +18,7 @@
         "@types/common-tags": "1.8.1",
         "@types/jest": "29.2.1",
         "@types/mousetrap": "1.6.10",
-        "@types/node": "18.11.8",
+        "@types/node": "18.11.9",
         "@types/react": "18.0.24",
         "@types/react-dom": "18.0.8",
         "@typescript-eslint/eslint-plugin": "5.42.0",
@@ -2865,10 +2865,11 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.11.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.8.tgz",
-      "integrity": "sha512-uGwPWlE0Hj972KkHtCDVwZ8O39GmyjfMane1Z3GUBGGnkZ2USDq7SxLpVIiIHpweY9DS0QTDH0Nw7RNBsAAZ5A==",
-      "dev": true
+      "version": "18.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -12518,9 +12519,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.11.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.8.tgz",
-      "integrity": "sha512-uGwPWlE0Hj972KkHtCDVwZ8O39GmyjfMane1Z3GUBGGnkZ2USDq7SxLpVIiIHpweY9DS0QTDH0Nw7RNBsAAZ5A==",
+      "version": "18.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
       "dev": true
     },
     "@types/parse-json": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "textarea-markdown-editor",
-  "version": "1.0.5-rc.3",
+  "name": "headless-mde",
+  "version": "0.1.0",
   "description": "UI headless React markdown editor using only textarea",
-  "homepage": "https://github.com/Resetand/markdown-textarea",
+  "homepage": "https://github.com/can3p/headless-mde",
   "author": "Resetand",
   "license": "MIT",
   "keywords": [

--- a/src/lib/Cursor.new.ts
+++ b/src/lib/Cursor.new.ts
@@ -166,7 +166,7 @@ export class Cursor {
         const normalizedContent = this.normalizeSelection(content);
 
         // PATCH: Use surgical insertion at cursor position
-        const data = this.execRaw(content);
+        const data = this.execRaw(normalizedContent);
         if (process.env.NODE_ENV === 'test') {
             const newValue = this.value.slice(0, cursorAt) + data.text + this.value.slice(cursorAt);
             this.element.value = newValue;
@@ -177,9 +177,8 @@ export class Cursor {
 
         // Set cursor position after inserted text
         if (data.selectionStart !== null && data.selectionEnd !== null) {
-            const offset = start;
-            this.element.selectionStart = offset + data.selectionStart;
-            this.element.selectionEnd = offset + data.selectionEnd;
+            this.element.selectionStart = cursorAt + data.selectionStart;
+            this.element.selectionEnd = cursorAt + data.selectionEnd;
         }
     }
 

--- a/src/lib/Cursor.new.ts
+++ b/src/lib/Cursor.new.ts
@@ -176,9 +176,9 @@ export class Cursor {
         }
 
         // Set cursor position after inserted text
-        if (data.selectionStart !== null && data.selectionEnd !== null) {
+        if (data.selectionStart !== null) {
             this.element.selectionStart = cursorAt + data.selectionStart;
-            this.element.selectionEnd = cursorAt + data.selectionEnd;
+            this.element.selectionEnd = cursorAt + (data.selectionEnd ?? data.selectionStart);
         }
     }
 

--- a/src/lib/Cursor.new.ts
+++ b/src/lib/Cursor.new.ts
@@ -301,8 +301,8 @@ export class Cursor {
         const end = this.selection?.selectionEnd ?? this.position.cursorAt;
 
         if (this.isSelectedWrappedWith(markup) && unwrap) {
-            // PATCH: Unwrap - use surgical replacement
-            const unwrappedContent = text.slice(start, end);
+            // PATCH: Unwrap - use surgical replacement with MARKERs for cursor positioning
+            const unwrappedContent = MARKER + text.slice(start, end) + MARKER;
             const data = this.execRaw(unwrappedContent);
             // Replace from (start - prefix.length) to (end + suffix.length)
             fireInput(this.element, data.text, start - prefix.length, end + suffix.length);
@@ -316,8 +316,8 @@ export class Cursor {
             return;
         }
 
-        // PATCH: Wrap - use surgical replacement
-        const wrappedContent = prefix + (text.slice(start, end) || placeholder) + suffix;
+        // PATCH: Wrap - use surgical replacement with MARKERs for cursor positioning
+        const wrappedContent = prefix + MARKER + (text.slice(start, end) || placeholder) + MARKER + suffix;
         const data = this.execRaw(wrappedContent);
         fireInput(this.element, data.text, start, end);
 

--- a/src/lib/Cursor.new.ts
+++ b/src/lib/Cursor.new.ts
@@ -123,27 +123,11 @@ export class Cursor {
         return { cursorAt: position, line };
     }
 
-    public setValue(text: string) {
-        const data = this.execRaw(text);
-
-        // TODO check if there are other way to make it work
-        if (process.env.NODE_ENV === 'test') {
-            this.element.value = data.text;
-        } else {
-            fireInput(this.element, data.text);
-        }
-
-        if (data.selectionStart === null && data.selectionEnd === null) {
-            return;
-        }
-
-        // if no end of selection or start == end
-        if (data.selectionStart !== null && (data.selectionEnd === null || data.selectionStart === data.selectionEnd)) {
-            this.element.selectionStart = data.selectionStart;
-            this.element.selectionEnd = data.selectionStart;
-        } else {
-            this.element.setSelectionRange(data.selectionStart!, data.selectionEnd!);
-        }
+    /**
+     * @returns {number} total number of lines
+     * */
+    public totalLines(): number {
+        return this.lines.length;
     }
 
     /**
@@ -158,23 +142,89 @@ export class Cursor {
      * if some content is selected will replace it
      */
     public insert(content: string) {
+        const normalizedContent = this.normalizeSelection(content);
         if (!this.selection) {
             this.insertAtCursor(content);
             return;
         }
         const start = this.selection.selectionStart;
         const end = this.selection.selectionEnd;
-        const newValue = this.value.slice(0, start) + this.normalizeSelection(content) + this.value.slice(end);
-        this.setValue(newValue);
+        
+        // PATCH: Use surgical insertion - only replace selected range
+        const data = this.execRaw(normalizedContent);
+        if (process.env.NODE_ENV === 'test') {
+            const newValue = this.value.slice(0, start) + data.text + this.value.slice(end);
+            this.element.value = newValue;
+        } else {
+            // Pass selection range to fireInput for surgical replacement
+            fireInput(this.element, data.text, start, end);
+        }
+        
+        // Set cursor position after inserted text
+        if (data.selectionStart !== null && data.selectionEnd !== null) {
+            const offset = start;
+            this.element.selectionStart = offset + data.selectionStart;
+            this.element.selectionEnd = offset + data.selectionEnd;
+        }
     }
 
     private insertAtCursor(content: string) {
         const cursorAt = this.position.cursorAt;
-        const newValue =
-            this.value.slice(0, cursorAt) +
-            this.normalizeSelection(content) +
-            this.value.slice(cursorAt, this.value.length);
-        this.setValue(newValue);
+        const normalizedContent = this.normalizeSelection(content);
+        
+        // PATCH: Use surgical insertion at cursor position
+        const data = this.execRaw(normalizedContent);
+        if (process.env.NODE_ENV === 'test') {
+            const newValue = this.value.slice(0, cursorAt) + data.text + this.value.slice(cursorAt);
+            this.element.value = newValue;
+        } else {
+            // Insert at cursor (replace zero-length selection)
+            fireInput(this.element, data.text, cursorAt, cursorAt);
+        }
+        
+        // Set cursor position after inserted text
+        if (data.selectionStart !== null && data.selectionEnd !== null) {
+            this.element.selectionStart = cursorAt + data.selectionStart;
+            this.element.selectionEnd = cursorAt + data.selectionEnd;
+        }
+    }
+
+    /**
+     * Insert content and scroll it into view if it's below the visible area
+     */
+    public insertAndScrollIntoView(content: string) {
+        const cursorPositionBefore = this.element.selectionStart;
+        this.insert(content);
+        
+        // Scroll into view if inserted content is below visible area
+        const textarea = this.element;
+        const lineHeight = parseInt(window.getComputedStyle(textarea).lineHeight) || 20;
+        const cursorLine = textarea.value.substring(0, cursorPositionBefore).split('\n').length;
+        const cursorPixelPosition = cursorLine * lineHeight;
+        const visibleBottom = textarea.scrollTop + textarea.clientHeight;
+        
+        if (cursorPixelPosition > visibleBottom) {
+            // Content is below visible area, scroll it into view
+            textarea.scrollTop = cursorPixelPosition - textarea.clientHeight + lineHeight * 2;
+        }
+    }
+
+    /**
+     * Find and replace text while preserving scroll position
+     * @param searchText - Text to find
+     * @param replacement - Text to replace with
+     */
+    public replace(searchText: string, replacement: string) {
+        const searchStart = this.value.indexOf(searchText);
+        if (searchStart === -1) {
+            return; // Text not found
+        }
+        const searchEnd = searchStart + searchText.length;
+        
+        // Preserve scroll position
+        const savedScrollTop = this.element.scrollTop;
+        fireInput(this.element, replacement, searchStart, searchEnd);
+        this.element.scrollTop = savedScrollTop;
     }
 
     /**
@@ -198,12 +248,16 @@ export class Cursor {
 
         const start = selectedLines[0].startsAt;
         const end = selectedLines[selectedLines.length - 1].endsAt;
-        const newValue =
-            this.value.slice(0, start) +
-            this.normalizeSelection(content, selectReplaced ? 'SELECT_ALL' : 'TO_END') +
-            this.value.slice(end);
-
-        this.setValue(newValue);
+        
+        // PATCH: Use surgical insertion instead of setValue to avoid scroll jumps
+        const data = this.execRaw(this.normalizeSelection(content, selectReplaced ? 'SELECT_ALL' : 'TO_END'));
+        fireInput(this.element, data.text, start, end);
+        
+        // Set cursor position after replaced text
+        if (data.selectionStart !== null && data.selectionEnd !== null) {
+            this.element.selectionStart = start + data.selectionStart;
+            this.element.selectionEnd = start + data.selectionEnd;
+        }
     }
 
     /**
@@ -219,12 +273,27 @@ export class Cursor {
         const start = line.startsAt;
         const end = line.endsAt;
         if (content === null) {
-            // line should be removed
-            this.setValue(this.value.slice(0, start - 1) + MARKER + this.value.slice(end));
+            // PATCH: line should be removed - use surgical deletion
+            const data = this.execRaw('');
+            // Remove from start-1 (including newline) to end
+            fireInput(this.element, data.text, start - 1, end);
+            // Set cursor position
+            if (data.selectionStart !== null) {
+                this.element.selectionStart = start - 1 + data.selectionStart;
+                this.element.selectionEnd = start - 1 + data.selectionStart;
+            }
             return;
         }
-        const newValue = this.value.slice(0, start) + this.normalizeSelection(content) + this.value.slice(end);
-        this.setValue(newValue);
+        
+        // PATCH: Use surgical insertion instead of setValue
+        const data = this.execRaw(this.normalizeSelection(content));
+        fireInput(this.element, data.text, start, end);
+        
+        // Set cursor position after replaced text
+        if (data.selectionStart !== null && data.selectionEnd !== null) {
+            this.element.selectionStart = start + data.selectionStart;
+            this.element.selectionEnd = start + data.selectionEnd;
+        }
     }
 
     /**
@@ -238,30 +307,31 @@ export class Cursor {
         const end = this.selection?.selectionEnd ?? this.position.cursorAt;
 
         if (this.isSelectedWrappedWith(markup) && unwrap) {
-            const content = [
-                text.slice(0, start - prefix.length),
-                MARKER,
-                text.slice(start, end),
-                MARKER,
-                text.slice(end + suffix.length),
-            ].join('');
-
-            this.setValue(content);
+            // PATCH: Unwrap - use surgical replacement
+            const unwrappedContent = text.slice(start, end);
+            const data = this.execRaw(unwrappedContent);
+            // Replace from (start - prefix.length) to (end + suffix.length)
+            fireInput(this.element, data.text, start - prefix.length, end + suffix.length);
+            
+            // Set cursor position
+            if (data.selectionStart !== null && data.selectionEnd !== null) {
+                const offset = start - prefix.length;
+                this.element.selectionStart = offset + data.selectionStart;
+                this.element.selectionEnd = offset + data.selectionEnd;
+            }
             return;
         }
-
-        const content = [
-            //
-            text.slice(0, start),
-            prefix,
-            MARKER,
-            text.slice(start, end) || placeholder,
-            MARKER,
-            suffix,
-            text.slice(end),
-        ].join('');
-
-        this.setValue(content);
+        
+        // PATCH: Wrap - use surgical replacement
+        const wrappedContent = prefix + (text.slice(start, end) || placeholder) + suffix;
+        const data = this.execRaw(wrappedContent);
+        fireInput(this.element, data.text, start, end);
+        
+        // Set cursor position
+        if (data.selectionStart !== null && data.selectionEnd !== null) {
+            this.element.selectionStart = start + data.selectionStart;
+            this.element.selectionEnd = start + data.selectionEnd;
+        }
     }
 
     private isSelectedWrappedWith(markup: string | [string, string]) {

--- a/src/lib/extensions.ts
+++ b/src/lib/extensions.ts
@@ -153,16 +153,17 @@ export const prefixWrappingExtension: Extension = (textarea, options) => {
             // no matches
             return;
         }
-        
+
         const { prefix, shouldBreak, shouldSaveIndent } = matched;
         if (shouldBreak) {
             // for a list line without content remove prefix of this line before default behavior
             cursor.replaceLine(enteringLine.lineNumber, '');
             return;
         }
-        
+
+        // PATCH: Let Enter key create newline naturally (like GitHub), then insert only the prefix
         const indent = shouldSaveIndent ? getIndent(enteringLine.text) : '';
-        
+
         // PATCH: In test environment, use old approach (preventDefault + manual insertion)
         // In browser, let Enter work naturally and insert prefix via input event (fixes scroll bug)
         if (process.env.NODE_ENV === 'test') {
@@ -172,7 +173,7 @@ export const prefixWrappingExtension: Extension = (textarea, options) => {
             // Let Enter key create newline naturally (like GitHub), then insert only the prefix
             // Use input event to ensure newline exists before inserting prefix (fixes Firefox race condition)
             const prefixToInsert = `${indent}${prefix}${Cursor.MARKER}`;
-            
+
             textarea.addEventListener('input', function() {
                 cursor.insert(prefixToInsert);
             }, { once: true });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -25,19 +25,6 @@ export const isBtwOrEq = (value: number, a: number, b: number) => {
     return value >= Math.min(a, b) && value <= Math.max(a, b);
 };
 
-let browserSupportsTextareaTextNodes: any;
-function canManipulateViaTextNodes(input: HTMLTextAreaElement | HTMLInputElement): boolean {
-    if (input.nodeName !== 'TEXTAREA') {
-        return false;
-    }
-    if (typeof browserSupportsTextareaTextNodes === 'undefined') {
-        const textarea: HTMLTextAreaElement = document.createElement('textarea');
-        textarea.value = '1';
-        browserSupportsTextareaTextNodes = Boolean(textarea.firstChild);
-    }
-    return browserSupportsTextareaTextNodes;
-}
-
 /**
  * @param {HTMLTextAreaElement|HTMLInputElement} input
  * @param {string} value - The text to insert

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -40,89 +40,73 @@ function canManipulateViaTextNodes(input: HTMLTextAreaElement | HTMLInputElement
 
 /**
  * @param {HTMLTextAreaElement|HTMLInputElement} input
- * @param {string} value
+ * @param {string} value - The text to insert
+ * @param {number} [selectionStart] - Optional start of selection range to replace
+ * @param {number} [selectionEnd] - Optional end of selection range to replace
  * @returns {void}
  */
-export function fireInput(input: HTMLTextAreaElement | HTMLInputElement, value: string): void {
-    // clear value before insertion
+export function fireInput(
+    input: HTMLTextAreaElement | HTMLInputElement,
+    value: string,
+    selectionStart?: number,
+    selectionEnd?: number,
+): void {
+    // PATCH: Rewritten to use GitHub's approach - avoid select() to prevent Chrome scroll bug
+    // Use surgical selection ranges and contentEditable trick for execCommand
 
-    // Most of the used APIs only work with the field selected
-    input.focus();
+    // If selection range provided, use it; otherwise replace all content
+    const start = typeof selectionStart === 'number' ? selectionStart : 0;
+    const end = typeof selectionEnd === 'number' ? selectionEnd : input.value.length;
 
-    // since we replace all content
-    input.select();
+    // Set selection to the range we want to replace
+    input.selectionStart = start;
+    input.selectionEnd = end;
 
-    // Webkit + Edge
-    const isSuccess = document.execCommand && document.execCommand('insertText', false, value);
+    let isSuccess = false;
 
+    // Try execCommand with contentEditable trick (GitHub's approach)
+    if (document.execCommand) {
+        const originalContentEditable = (input as any).contentEditable;
+        try {
+            (input as any).contentEditable = 'true';
+            isSuccess = document.execCommand('insertText', false, value);
+            (input as any).contentEditable = originalContentEditable;
+        } catch (e) {
+            (input as any).contentEditable = originalContentEditable;
+            isSuccess = false;
+        }
+    }
+
+    // Fallback: manual value manipulation
     if (!isSuccess) {
-        const start = input.selectionStart!;
-        const end = input.selectionEnd!;
-
-        // Firefox (non-standard method)
-        if (typeof input.setRangeText === 'function') {
-            input.setRangeText(value);
-        } else {
-            //
-            // To make a change we just need a Range, not a Selection
-            const range = document.createRange();
-            const textNode = document.createTextNode(value);
-
-            if (canManipulateViaTextNodes(input)) {
-                let node = input.firstChild;
-
-                // If textarea is empty, just insert the text
-                if (!node) {
-                    input.appendChild(textNode);
-                } else {
-                    // Otherwise we need to find a nodes for start and end
-                    let offset = 0;
-                    let startNode = null;
-                    let endNode = null;
-
-                    while (node && (startNode === null || endNode === null)) {
-                        const nodeLength = node.nodeValue!.length;
-
-                        // if start of the selection falls into current node
-                        if (start >= offset && start <= offset + nodeLength) {
-                            range.setStart((startNode = node), start - offset);
-                        }
-
-                        // if end of the selection falls into current node
-                        if (end >= offset && end <= offset + nodeLength) {
-                            range.setEnd((endNode = node), end - offset);
-                        }
-
-                        offset += nodeLength;
-                        node = node.nextSibling;
-                    }
-
-                    // If there is some text selected, remove it as we should replace it
-                    if (start !== end) {
-                        range.deleteContents();
-                    }
-                }
-            }
-
-            // If the node is a textarea and the range doesn't span outside the element
-            //
-            // Get the commonAncestorContainer of the selected range and test its type
-            // If the node is of type `#text` it means that we're still working with text nodes within our textarea element
-            // otherwise, if it's of type `#document` for example it means our selection spans outside the textarea.
-            if (canManipulateViaTextNodes(input) && range.commonAncestorContainer.nodeName === '#text') {
-                // Finally insert a new node. The browser will automatically split start and end nodes into two if necessary
-                range.insertNode(textNode);
-            } else {
-                // If the node is not a textarea or the range spans outside a textarea the only way is to replace the whole value
-                input.value = value;
-            }
+        // Try to preserve undo/redo for IE/Edge
+        try {
+            document.execCommand('ms-beginUndoUnit');
+        } catch (e) {
+            // Ignore
         }
 
-        // Notify any possible listeners of the change
-        const e = document.createEvent('UIEvent');
-        e.initEvent('input', true, false);
-        input.dispatchEvent(e);
+        // Manually replace the selected range
+        const newValue = input.value.slice(0, start) + value + input.value.slice(end);
+        input.value = newValue;
+
+        try {
+            document.execCommand('ms-endUndoUnit');
+        } catch (e) {
+            // Ignore
+        }
+
+        // Manually dispatch input event
+        const event = document.createEvent('UIEvent');
+        event.initEvent('input', true, false);
+        input.dispatchEvent(event);
     }
+
+    // PATCH: Explicitly set cursor position after insertion (GitHub's approach)
+    // Position cursor at the end of inserted text
+    const newCursorPos = start + value.length;
+    input.selectionStart = newCursorPos;
+    input.selectionEnd = newCursorPos;
 }
 
 /**

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -88,12 +88,9 @@ export function fireInput(
         event.initEvent('input', true, false);
         input.dispatchEvent(event);
     }
-
-    // PATCH: Explicitly set cursor position after insertion (GitHub's approach)
-    // Position cursor at the end of inserted text
-    const newCursorPos = start + value.length;
-    input.selectionStart = newCursorPos;
-    input.selectionEnd = newCursorPos;
+    
+    // PATCH: Don't set cursor position here - let calling code handle it
+    // Cursor positioning is done by the Cursor methods using MARKER positions from execRaw
 }
 
 /**

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -53,15 +53,13 @@ export function fireInput(
 
     // Try execCommand with contentEditable trick (GitHub's approach)
     if (document.execCommand) {
-        const originalContentEditable = (input as any).contentEditable;
+        input.contentEditable = 'true';
         try {
-            (input as any).contentEditable = 'true';
             isSuccess = document.execCommand('insertText', false, value);
-            (input as any).contentEditable = originalContentEditable;
         } catch (e) {
-            (input as any).contentEditable = originalContentEditable;
             isSuccess = false;
         }
+        input.contentEditable = 'false';
     }
 
     // Fallback: manual value manipulation
@@ -88,9 +86,12 @@ export function fireInput(
         event.initEvent('input', true, false);
         input.dispatchEvent(event);
     }
-    
-    // PATCH: Don't set cursor position here - let calling code handle it
-    // Cursor positioning is done by the Cursor methods using MARKER positions from execRaw
+
+    // PATCH: Explicitly set cursor position after insertion (GitHub's approach)
+    // Position cursor at the end of inserted text
+    const newCursorPos = start + value.length;
+    input.selectionStart = newCursorPos;
+    input.selectionEnd = newCursorPos;
 }
 
 /**


### PR DESCRIPTION
A bunch of changes that prevent form scrolling to the top in different situations. Instead of replacing the whole text value the new logic uses `document.runCommand` to insert only changed pieces of text